### PR TITLE
Fix: resolve stand tech debt 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           file: ./app/backend/Dockerfile
           push: false
           outputs: type=docker,dest=${{ runner.temp }}/backend.tar
-          tags: ${{ vars.DOCKERHUB_USERNAME }}/tinytasks-backend:sha-${{ steps.get_short_sha.outputs.short_sha }}
+          tags: tinytasks-backend:sha-${{ steps.get_short_sha.outputs.short_sha }}
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend
       - name: Upload backend image artifact
@@ -191,7 +191,7 @@ jobs:
           file: ./app/frontend/Dockerfile
           push: false
           outputs: type=docker,dest=${{ runner.temp }}/frontend.tar
-          tags: ${{ vars.DOCKERHUB_USERNAME }}/tinytasks-frontend:sha-${{ steps.get_short_sha.outputs.short_sha }}
+          tags: tinytasks-frontend:sha-${{ steps.get_short_sha.outputs.short_sha }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
       - name: Upload frontend image artifact
@@ -212,7 +212,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}  
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Get short SHA

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,49 @@
-# Python virtual environments
-/app/backend/venv
-/app/backend/.venv
-
-# Python cache files
-__pycache__/
-*.pyc
-
-# Alembic logs
-/app/backend/alembic/*.log
-
 # Environment files
 .env
+.env.*
+!.env.example
 
-# Frontend cache/build artifacts
-/app/frontend/.vite
-/app/frontend/dist
+# Python virtual environments
+.venv/
+venv/
+env/
 
-# Local SQLite DB for dev only
-# Remove later if no longer needed
-/app/backend/tinytasks.db
+# Python cache / bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Python tooling
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+coverage.xml
+htmlcov/
+
+# Alembic logs
+app/backend/alembic/*.log
+
+# Local databases
+*.sqlite
+*.sqlite3
+*.db
+app/backend/tinytasks.db
+
+# Frontend dependencies / cache / build artifacts
+node_modules/
+dist/
+.vite/
+
+# Logs
+*.log
 
 # Editor settings
 .vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -30,11 +30,19 @@ It includes a FastAPI backend, React frontend, Docker-based local environment, a
 - REST semantics
 - normalized Prometheus route labels (no high cardinality)
 
+### CI/CD
+
+- GitHub Actions pipeline for backend tests and frontend build.
+- Backend test coverage report generated with pytest-cov.
+- Backend linting and formatting checks with Ruff.
+- Frontend linting and production build checks.
+- Docker image build jobs for backend and frontend.
+- Docker Hub publishing for backend and frontend images on pushes to `main`.
+
 ---
 
 ## Not implemented yet
 
-- CI pipeline (GitHub Actions)
 - Kubernetes / Helm
 - ArgoCD / GitOps
 - Terraform / Ansible
@@ -67,16 +75,19 @@ It includes a FastAPI backend, React frontend, Docker-based local environment, a
 ---
 
 ## Project structure
+
+```text
 ├── app
-│ ├── backend
-│ │ ├── alembic
-│ │ ├── src
-│ │ ├── tests
-│ │ └── Dockerfile
-│ └── frontend
-│ ├── src
-│ ├── Dockerfile
-│ └── nginx.conf
+│   ├── backend
+│   │   ├── alembic
+│   │   ├── src
+│   │   ├── tests
+│   │   └── Dockerfile
+│   └── frontend
+│       ├── src
+│       ├── Dockerfile
+│       └── nginx.conf
 ├── docker-compose.yml
 └── .env.example
+```
 

--- a/app/backend/alembic.ini
+++ b/app/backend/alembic.ini
@@ -3,7 +3,7 @@
 [alembic]
 # path to migration scripts
 # Use forward slashes (/) also on windows to provide an os agnostic path
-script_location = alembic
+script_location = %(here)s/alembic
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/app/backend/alembic/env.py
+++ b/app/backend/alembic/env.py
@@ -8,12 +8,13 @@ from sqlalchemy import create_engine
 
 from alembic import context
 
-# --- Make sure src/ is importable (so Alembic can see our models) ---
+# --- Make sure the backend package is importable for Alembic ---
 BASE_DIR = Path(__file__).resolve().parents[1]
-SRC_DIR = BASE_DIR / "src"
-if str(SRC_DIR) not in sys.path:
-    sys.path.insert(0, str(SRC_DIR))
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
 
+# Import models so SQLAlchemy registers them in Base.metadata for Alembic autogenerate.
+from src import models  # noqa: F401, E402
 from src.config import get_database_url  # noqa: E402
 from src.db import Base  # noqa: E402
 

--- a/app/backend/src/db.py
+++ b/app/backend/src/db.py
@@ -56,6 +56,9 @@ def get_db() -> Session:
     db: Session = get_session_local()()
     try:
         yield db
+    except Exception:
+        db.rollback()
+        raise
     finally:
         db.close()
 

--- a/app/backend/src/main.py
+++ b/app/backend/src/main.py
@@ -47,15 +47,15 @@ async def prometheus_middleware(request: Request, call_next):
     method = request.method
     status_code = 500
 
-    route = request.scope.get("route")
-    path = route.path if route and hasattr(route, "path") else request.url.path
-
     try:
         response = await call_next(request)
         status_code = response.status_code
         return response
     finally:
         duration = perf_counter() - start
+
+        route = request.scope.get("route")
+        path = route.path if route and hasattr(route, "path") else request.url.path
 
         REQUEST_COUNT.labels(
             method=method,

--- a/app/backend/tests/test_basic.py
+++ b/app/backend/tests/test_basic.py
@@ -54,6 +54,31 @@ def test_metrics_endpoint(client):
     assert "http_requests_total" in response.text
 
 
+def test_metrics_use_normalized_route_labels(client):
+    # Create a task so we can call a dynamic route with a real UUID.
+    created_response = client.post("/api/tasks", json={"title": "Metric route test"})
+    assert created_response.status_code == 201
+
+    task_id = created_response.json()["id"]
+
+    # Call the endpoint that uses a path parameter: /api/tasks/{task_id}.
+    # The real request URL contains a UUID, but Prometheus labels must use
+    # the normalized FastAPI route template instead of the raw URL.
+    response = client.get(f"/api/tasks/{task_id}")
+    assert response.status_code == 200
+
+    # Fetch Prometheus metrics after the dynamic route was called.
+    metrics_response = client.get("/metrics")
+    assert metrics_response.status_code == 200
+
+    # The metrics output should contain the normalized route template.
+    assert "/api/tasks/{task_id}" in metrics_response.text
+
+    # The concrete UUID must not appear in metrics labels, otherwise every task
+    # would create a separate Prometheus time series and cause high cardinality.
+    assert task_id not in metrics_response.text
+
+
 def test_create_task_success(client):
     # Send valid payload to create a new task
     payload = {"title": "Buy milk"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       timeout: 3s
       retries: 10
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
   backend:
     build:
       context: ./app/backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,18 +3,23 @@ services:
     image: postgres:16
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
     volumes:
       - db_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:?POSTGRES_USER is required} -d ${POSTGRES_DB:?POSTGRES_DB is required}",
+        ]
       interval: 5s
       timeout: 3s
       retries: 10
     ports:
       - "127.0.0.1:5432:5432"
+
   backend:
     build:
       context: ./app/backend
@@ -26,9 +31,10 @@ services:
         condition: service_healthy
     environment:
       # App will read DATABASE_URL from env; Alembic too (entrypoint)
-      DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db:5432/${POSTGRES_DB:?POSTGRES_DB is required}
     ports:
       - "8080:8080"
+
   frontend:
     build:
       context: ./app/frontend
@@ -39,6 +45,7 @@ services:
       backend:
         condition: service_healthy
     ports:
-      - "5173:80"   
+      - "5173:80"
+
 volumes:
   db_data:


### PR DESCRIPTION
## Summary

This PR fixes several technical debt items before moving the project to the next DevOps stage: remote Kubernetes deployment, Terraform, and Ansible.

## Changes

- Fixed Prometheus route label normalization to prevent UUIDs from appearing in `/metrics`.
- Added a regression test to ensure dynamic task IDs are not exported as Prometheus path labels.
- Fixed Alembic model loading so `autogenerate` can see the `Task` model.
- Updated Alembic `script_location` to work correctly when running from the repository root.
- Decoupled non-publish Docker build jobs from Docker Hub variables.
- Updated README to reflect the implemented CI/CD pipeline.
- Restricted the local Postgres port binding to `127.0.0.1`.
- Added required environment variable checks to `docker-compose.yml`.
- Added explicit rollback handling in the FastAPI DB session dependency.
- Expanded `.gitignore` for local caches, virtual environments, build artifacts, and database files.

## Validation

Validated locally with:

- `cd app/backend && pytest -q`
- `cd app/backend && ruff check .`
- `cd app/backend && ruff format --check .`
- `cd app/frontend && npm run build`
- `cd app/frontend && npm run lint`
- `docker compose config`

## Notes

SQLite Alembic migration compatibility and minor frontend UX polish were intentionally left for the backlog because they are not blocking the current DevOps/Kubernetes preparation stage.